### PR TITLE
Fixed "greater than" in randomCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Set<Int>(randomCount: 5)  // {15, 78, 68, 77, 40}
 
 ###### Warning:
 
-The `randomCount` parameter must be greater than the total number of possible
+The `randomCount` parameter must be less than the total number of possible
 values that the given `RandomType` can produce. Otherwise, the initializer will
 never finish.
 


### PR DESCRIPTION
randomCount must be *less* than (not greater than) the total values the type can produce (otherwise the initializer never finishes), correct?

Not sure, however, if being "equal to" still assures the initializer will finish..