### PR TITLE
Fixed compilation with Xcode 8.0 beta 3

### DIFF
--- a/RandomKit.xcodeproj/project.pbxproj
+++ b/RandomKit.xcodeproj/project.pbxproj
@@ -657,6 +657,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -681,6 +682,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -735,7 +737,6 @@
 				PRODUCT_NAME = RandomKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -785,7 +786,6 @@
 				PRODUCT_NAME = RandomKit;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1048,7 +1048,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1089,7 +1088,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.nikolaivazquez.RandomKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Sources/URL+RandomKit.swift
+++ b/Sources/URL+RandomKit.swift
@@ -58,7 +58,7 @@ extension URL: RandomType {
     /// - Parameters:
     ///     - values: The values from which the URL is generated.
     public static func random(fromValues values: [String]) -> URL {
-        guard let value = values.random, url = self.init(string: value) else {
+        guard let value = values.random, let url = self.init(string: value) else {
             return self.init(string: "https://www.google.com/")!
         }
         return url


### PR DESCRIPTION
I've fixed a warning and moved the `SWIFT_VERSION` definition to the project level (and removed it from targets) so that all targets have it. This fixes compilation with beta 3.