### PR TITLE
Add RandomBytesIterator type

### DIFF
--- a/Sources/RandomKit/Types/RandomGenerator/RandomBytesGenerator.swift
+++ b/Sources/RandomKit/Types/RandomGenerator/RandomBytesGenerator.swift
@@ -26,7 +26,7 @@
 //
 
 /// A type that specializes in generating random bytes in the form of a `Bytes` type.
-public protocol RandomBytesGenerator: RandomGenerator {
+public protocol RandomBytesGenerator: RandomGenerator, Sequence {
 
     /// A type that stores bytes within its own value.
     associatedtype Bytes
@@ -34,6 +34,42 @@ public protocol RandomBytesGenerator: RandomGenerator {
     /// Returns random `Bytes`.
     mutating func randomBytes() -> Bytes
 
+    /// Returns an iterator over the elements of this sequence.
+    func makeIterator() -> RandomBytesIterator<Self>
+
+}
+
+/// An iterator over the `Byte`s of a `RandomBytesGenerator` source.
+///
+/// ```
+/// func perform(with randomValue: UInt64) -> Bool {
+///     ...
+/// }
+///
+/// for x in Xoroshiro.seeded {
+///     guard perform(with: x) else {
+///         break
+///     }
+///     ...
+/// }
+/// ```
+public struct RandomBytesIterator<Source: RandomBytesGenerator>: IteratorProtocol {
+
+    /// The source generator from which `next()` retrieves values.
+    public var source: Source
+
+    /// Advances to the next element and returns it.
+    public mutating func next() -> Source.Bytes? {
+        return source.randomBytes()
+    }
+
+}
+
+extension RandomBytesGenerator {
+    /// Returns an iterator over the elements of this sequence.
+    public func makeIterator() -> RandomBytesIterator<Self> {
+        return RandomBytesIterator(source: self)
+    }
 }
 
 extension RandomBytesGenerator where Bytes == UInt64 {


### PR DESCRIPTION
This turns all `RandomBytesGenerator` into infinite `Sequence`s of their `Bytes` type.

This type allows for consuming and iterating over a RandomBytesGenerator without having to call `randomBytes()` directly. This mainly serves as a convenience.

This is different than `Randoms-` types because it doesn't take a mutable pointer to the source `RandomGenerator`. So, unless the iterator is shared, there is unique access to the generator.

It would be nice if there was a `take(_:)` method for `Sequence`s to supplement this and `Randoms`.