### PR TITLE
[WIP] Migrate to Swift 4.1

### DIFF
--- a/Sources/RandomKit/Extensions/Swift/Collection+RandomKit.swift
+++ b/Sources/RandomKit/Extensions/Swift/Collection+RandomKit.swift
@@ -78,22 +78,13 @@ extension RandomRetrievableInRange where Self: Collection, Self.Index: RandomInR
 
 }
 
-extension RandomRetrievableInRange where Self: Collection, Self.Index: RandomInRange, Self.IndexDistance: RandomToValue {
-
-    /// Returns a random element in `range` without checking whether `self` or `range` is empty.
-    public func uncheckedRandom<R: RandomGenerator>(in range: Range<Index>, using randomGenerator: inout R) -> Iterator.Element {
-        return self[Index.uncheckedRandom(in: range, using: &randomGenerator)]
-    }
-
-}
-
-extension Collection where Self: RandomRetrievableInRange, IndexDistance: RandomToValue {
+extension Collection where Self: RandomRetrievableInRange {
 
     /// Returns a random element of `self`, or `nil` if `self` is empty.
     public func uncheckedRandom<R: RandomGenerator>(in range: Range<Index>, using randomGenerator: inout R) -> Iterator.Element {
         let upper = range.upperBound
         let lower = range.lowerBound
-        let elementIndex = IndexDistance.random(to: distance(from: lower, to: upper), using: &randomGenerator)
+        let elementIndex = Int.random(to: distance(from: lower, to: upper), using: &randomGenerator)
         return self[index(lower, offsetBy: elementIndex)]
     }
 


### PR DESCRIPTION
### TODO:

- [x] Deal with `IndexDistance` deprecation (it's always `Int` now)
- [ ] Deal with other deprecation warnings
- [x] Wait for compiler crash (I found https://bugs.swift.org/browse/SR-6797 while working on this).
- [x] Tests passing
- [ ] Wait for `Xcode 9.3`
- [ ] Update `.travis.yml`