### PR TITLE
use Swift 4

### DIFF
--- a/RandomKit.xcodeproj/project.pbxproj
+++ b/RandomKit.xcodeproj/project.pbxproj
@@ -1482,7 +1482,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1515,7 +1515,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
# My environment

macOS High Sierra 10.13.4
Xcode9.3

# Problem

I just cloned master and got compile error below.

```
/Users/omochi/github/omochi/RandomKit/Sources/RandomKit/Extensions/Swift/Collection+RandomKit.swift:100:17: Invalid redeclaration of 'uncheckedRandom(in:using:)'
/Users/omochi/github/omochi/RandomKit/Sources/RandomKit/Extensions/Swift/Collection+RandomKit.swift:75:17: 'uncheckedRandom(in:using:)' previously declared here
/Users/omochi/github/omochi/RandomKit/Sources/RandomKit/Extensions/Swift/Collection+RandomKit.swift:106:73: Type 'Collection.IndexDistance' (aka 'Int') in conformance requirement does not refer to a generic parameter or associated type
```

The lines with error is in macro section for Swift less than 4.1.
And a xcodeproj set swift version to 3.

# Solution

This PR changes Swift version from 3 to 4 and avoid this error.
