### PR TITLE
Xcscheme with xcode9.3

### DIFF
--- a/RandomKit.xcodeproj/project.pbxproj
+++ b/RandomKit.xcodeproj/project.pbxproj
@@ -1482,7 +1482,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1515,7 +1515,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/RandomKit.xcodeproj/xcshareddata/xcschemes/RandomKit iOS.xcscheme
+++ b/RandomKit.xcodeproj/xcshareddata/xcschemes/RandomKit iOS.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/RandomKit.xcodeproj/xcshareddata/xcschemes/RandomKit macOS.xcscheme
+++ b/RandomKit.xcodeproj/xcshareddata/xcschemes/RandomKit macOS.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/RandomKit.xcodeproj/xcshareddata/xcschemes/RandomKit tvOS.xcscheme
+++ b/RandomKit.xcodeproj/xcshareddata/xcschemes/RandomKit tvOS.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
With Xcode9.3, If I change `Show` checkbox on scheme management window,
Xcode make a little diff on xccheme files.

I use this library by gitsubmodule + carthage and add xcodeproj to xcworkspace for application development.
So this diff makes work repository state dirty.
Please merge this.

This PR includes my other PR (#56)